### PR TITLE
Changes for Freevo v1 to use kaa.epg

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -84,6 +84,12 @@ def get_channel(name):
     """
     return guide.get_channel(name)
 
+def get_channel_by_tuner_id(tuner_id):
+    """
+    Return the channel with the given tuner id.
+    """
+    return guide.get_channel_by_tuner_id(tuner_id)
+
 def search(channel=None, time=None, cls=Program, **kwargs):
     """
     Search the db.

--- a/src/guide.py
+++ b/src/guide.py
@@ -91,7 +91,9 @@ class Guide(object):
             # A critical rating for the show/film.  Should be out of 4.0.
             score = (float, ATTR_SEARCHABLE),
             # Bitmask for the kaa.epg.Program.FLAG_* constants
-            flags = (int, ATTR_SEARCHABLE)
+            flags = (int, ATTR_SEARCHABLE),
+            # List of credits (type, name, role)
+            credits = (list, ATTR_SIMPLE)
         )
         self._sync()
 

--- a/src/guide.py
+++ b/src/guide.py
@@ -121,7 +121,7 @@ class Guide(object):
                 else:
                     self._channels_by_tuner_id[t] = chan
 
-
+    @kaa.coroutine()
     def search(self, channel=None, time=None, cls=Program, **kwargs):
         """
         Search the EPG for programs.
@@ -213,7 +213,7 @@ class Guide(object):
             [ combine_attrs(row) for row in query_data ]
         if cls is None:
             # return raw data:
-            return query_data
+            yield query_data
 
         # Convert raw search result data from the server into python objects.
         results = []
@@ -224,7 +224,7 @@ class Guide(object):
                     continue
                 channel = self._channels_by_db_id[row['parent_id']]
             results.append(cls(channel, row))
-        return results
+        yield results
 
     def new_channel(self, tuner_id=None, name=None, long_name=None):
         """
@@ -284,18 +284,20 @@ class Guide(object):
         kaa.MainThreadCallable(self._sync)()
 
 
+    @kaa.coroutine()
     def get_keywords(self, associated=None, prefix=None):
         """
         Retrieves a list of keywords in the database.
         """
-        return self._db.get_inverted_index_terms('keywords', associated, prefix)
+        yield self._db.get_inverted_index_terms('keywords', associated, prefix)
 
 
+    @kaa.coroutine()
     def get_genres(self, associated=None, prefix=None):
         """
         Retrieves a list of genres in the database.
         """
-        return self._db.get_inverted_index_terms('genres', associated, prefix)
+        yield self._db.get_inverted_index_terms('genres', associated, prefix)
 
     @property
     def num_programs(self):

--- a/src/program.py
+++ b/src/program.py
@@ -83,6 +83,7 @@ class Program(object):
             self.flags = self._dbdata.get('flags')
             self.credits = self._dbdata.get('credits')
             self.date = self._dbdata.get('date')
+            self.year = self._dbdata.get('year')
             del self._dbdata
         return self.__getattribute__(attr)
 

--- a/src/program.py
+++ b/src/program.py
@@ -46,6 +46,12 @@ class Program(object):
     FLAG_NEW = 2
     #: If closed captioning is available for the program.
     FLAG_CC = 4
+    # If the program is premiere
+    FLAG_PREMIERE = 8
+    # If this is the last chance to see the program
+    FLAG_LAST_CHANCE = 16
+    # If this program has been previously shown
+    FLAG_PREVIOUSLY_SHOWN = 32
 
     def __init__(self, channel, dbdata):
         self.channel = channel
@@ -75,6 +81,7 @@ class Program(object):
             self.rating = self._dbdata.get('rating')
             self.score = self._dbdata.get('score')
             self.flags = self._dbdata.get('flags')
+            self.credits = self._dbdata.get('credits')
             del self._dbdata
         return self.__getattribute__(attr)
 

--- a/src/program.py
+++ b/src/program.py
@@ -82,6 +82,7 @@ class Program(object):
             self.score = self._dbdata.get('score')
             self.flags = self._dbdata.get('flags')
             self.credits = self._dbdata.get('credits')
+            self.date = self._dbdata.get('date')
             del self._dbdata
         return self.__getattribute__(attr)
 

--- a/src/rpc.py
+++ b/src/rpc.py
@@ -204,7 +204,6 @@ class Server(object):
     Server class for the epg.
     """
     def __init__(self, guide, address, secret):
-        print guide.num_programs
         self._clients = []
         # initial sync
         self.guide = guide

--- a/test/query.py
+++ b/test/query.py
@@ -1,32 +1,48 @@
 import time
+import kaa
 import kaa.epg
 
 def local():
+    print 'Starting'
     kaa.epg.load('test.db')
     print kaa.epg.get_channels()
     t1 = time.time()
-    result = kaa.epg.search(time=time.time())
+    result = kaa.epg.search(time=(time.time(), time.time() + 60*60)).wait()
     t2 = time.time()
     for r in result:
         print r.title, r.channel
-        print time.ctime(r.start)
+        print r.start, r.stop
+        print r.credits
+        print r.date
+        print r.year
         print
     print t2 - t1
+    result = kaa.epg.get_genres().wait()
+    print result
+    result = kaa.epg.search(genres=u'film').wait()
+    print result
 
 @kaa.coroutine()
 def rpc():
-    kaa.epg.connect()
+    kaa.epg.connect(('localhost', 10000))
     yield kaa.epg.guide.signals.subset('connected').any()
     print kaa.epg.get_channels()
+    print kaa.epg.guide.num_programs
     t1 = time.time()
     result = yield kaa.epg.search(time=time.time())
     t2 = time.time()
     print result
     print t2 - t1
+    result = yield kaa.epg.get_genres()
+    print result
+    result = yield kaa.epg.get_keywords()
+    print result
 
-if 1:
+
+if 0:
     rpc()
     kaa.main.run()
-if 0:
+
+if 1:
     local()
 

--- a/test/server.py
+++ b/test/server.py
@@ -4,5 +4,5 @@ import kaa.epg
 kaa.epg.load('test.db')
 print kaa.epg.get_channels()
 
-kaa.epg.listen()
+kaa.epg.listen(('localhost', 10000))
 kaa.main.run()


### PR DESCRIPTION
Hi guys,

I've been attempting to move freevo 1 over to kaa.epg and in the process I've been fixing a few bugs and making things a bit more consistent between server (local) and client (remote) queries.
- [Possibly contentious] I've changed the channel id in xmltv from the channel name to the xmltv id.
  The reason behind this is that the channel/tuner id bears no resemblance to the name/id used to tune a frontend in many cases and can change frequently/isn't under our control. Where as the xmltv id is well known method of mapping (all be it manually) to a tuner id.
- The kaa.epg.search/get_keywords/get_genres functions are now coroutines so that they work the same when using rpc as when using locally.
- I've added credits to the program object (only xmltv currently fills this in).
- RPC Client now also has access to the number of programs in the database.

A couple of other small bugs fixes.

Cheers

Adam
