### PR TITLE
Add get_grid method.

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -96,6 +96,13 @@ def search(channel=None, time=None, cls=Program, **kwargs):
     """
     return guide.search(channel, time, cls, **kwargs)
 
+def get_grid(channels, start_time, end_time, cls=Program):
+    """
+    Get a grid of programs.
+    """
+    return guide.get_grid(channels, start_time, end_time, cls)
+
+
 def get_keywords(associated=None, prefix=None):
     """
     Retrieves a list of keywords in the database.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -96,13 +96,6 @@ def search(channel=None, time=None, cls=Program, **kwargs):
     """
     return guide.search(channel, time, cls, **kwargs)
 
-def get_grid(channels, start_time, end_time, cls=Program):
-    """
-    Get a grid of programs.
-    """
-    return guide.get_grid(channels, start_time, end_time, cls)
-
-
 def get_keywords(associated=None, prefix=None):
     """
     Retrieves a list of keywords in the database.

--- a/src/program.py
+++ b/src/program.py
@@ -53,10 +53,11 @@ class Program(object):
     # If this program has been previously shown
     FLAG_PREVIOUSLY_SHOWN = 32
 
-    def __init__(self, channel, dbdata):
+    def __init__(self, channel, dbdata, extrainfo):
         self.channel = channel
         self._dbdata = dbdata
-
+        if extrainfo:
+            self.__dict__.update(extrainfo)
 
     def __getattr__(self, attr):
         """

--- a/src/rpc.py
+++ b/src/rpc.py
@@ -151,9 +151,9 @@ class Client(Guide):
                 time = to_timestamp(time[0]), to_timestamp(time[1])
             else:
                 time = to_timestamp(time)
-        query_data,extra_data = yield self.channel.rpc('search', channel, time, None, **kwargs)
+        query_data, extra_data = yield self.channel.rpc('search', channel, time, None, **kwargs)
         if cls is None:
-            yield  query_data,extra_data
+            yield  query_data, extra_data
         # Convert raw search result data from the server into python objects.
         yield self._rows_to_programs(cls, query_data, extra_data)
 
@@ -203,10 +203,6 @@ class Server(object):
         return self.guide.search(channel, time, cls, **kwargs)
 
     @kaa.rpc.expose()
-    def get_grid(self, channels, start_time, end_time, cls):
-        return self.guide.get_grid(channels, start_time, end_time, cls)
-
-    @kaa.rpc.expose()
     def get_keywords(self, associated=None, prefix=None):
         return self.guide.get_keywords(associated, prefix)
 
@@ -225,6 +221,7 @@ class Server(object):
         """
         Connect a new client to the server.
         """
+        log.info('Client connected: %s', client)
         client.rpc('_sync', self.guide._channels_by_name.values(), self.guide._num_programs)
         client.signals['closed'].connect(self.client_closed, client)
         self._clients.append(client)
@@ -235,4 +232,3 @@ class Server(object):
         """
         log.info('Client disconnected: %s', client)
         self._clients.remove(client)
-

--- a/test/grid.py
+++ b/test/grid.py
@@ -5,10 +5,10 @@ import kaa.epg
 
 
 def local():
-    def callback(id, extrainfo):
-        extrainfo['test'] = 'db_id : %d' % id
+    def callback(row, extrainfo):
+        extrainfo['test'] = 'db_id : %d' % row['id']
     guide = kaa.epg.load('test.db')
-    guide.register_program_callback(callback)
+    guide.signals['program-retrieved'].connect(callback)
 
 
 @kaa.coroutine()
@@ -37,11 +37,11 @@ def test():
         print
 
 
-if 0:
+if 1:
     print 'Local'
     local()
 
-if 1:
+if 0:
     print 'Remote'
     remote().wait()
 

--- a/test/grid.py
+++ b/test/grid.py
@@ -1,0 +1,39 @@
+import time
+import kaa
+import kaa.epg
+
+
+
+def local():
+    def callback(id, meta):
+        meta.test = 'db_id : %d' % id
+    guide = kaa.epg.load('test.db')
+    guide.register_grid_callback(callback)
+
+
+@kaa.coroutine()
+def remote():
+    g = kaa.epg.connect(('localhost', 10000))
+    yield g.signals.subset('connected').any()
+
+def test():
+    channels = kaa.epg.get_channels()
+    programs = kaa.epg.get_grid(channels[:2], time.time(), time.time() + (3 * 60 * 60)).wait()
+    assert(len(programs) == 2)
+    for i,channel in enumerate(programs):
+        print 'len(Programs)', len(channel)
+        for program in channel:
+            assert(program.channel == channels[i])
+            assert(hasattr(program, 'meta'))
+            assert(program.meta.test == 'db_id : %d' % program.db_id[1])
+
+
+if 1:
+    print 'Local'
+    local()
+
+if 0:
+    print 'Remote'
+    remote().wait()
+
+test()

--- a/test/grid.py
+++ b/test/grid.py
@@ -5,34 +5,43 @@ import kaa.epg
 
 
 def local():
-    def callback(id, meta):
-        meta.test = 'db_id : %d' % id
+    def callback(id, extrainfo):
+        extrainfo['test'] = 'db_id : %d' % id
     guide = kaa.epg.load('test.db')
-    guide.register_grid_callback(callback)
+    guide.register_program_callback(callback)
 
 
 @kaa.coroutine()
 def remote():
     g = kaa.epg.connect(('localhost', 10000))
-    yield g.signals.subset('connected').any()
+    yield kaa.inprogress(g.signals['connected'])
 
 def test():
     channels = kaa.epg.get_channels()
-    programs = kaa.epg.get_grid(channels[:2], time.time(), time.time() + (3 * 60 * 60)).wait()
-    assert(len(programs) == 2)
-    for i,channel in enumerate(programs):
-        print 'len(Programs)', len(channel)
-        for program in channel:
+    programs= kaa.epg.search(channels[:2], time=(time.time(), time.time() + (3 * 60 * 60))).wait()
+
+    #Separate into grid arrays
+    channel_programs = [[], []]
+    map_channel_programs = {channels[0]:channel_programs[0], channels[1]:channel_programs[1]}
+    for program in programs:
+        map_channel_programs[program.channel].append(program)
+
+
+    for i,programs in enumerate(channel_programs):
+        print channels[i].name, len(programs)
+        for program in programs:
+            print 'Title:', program.title, '(', program.start, '->', program.stop, ')'
             assert(program.channel == channels[i])
-            assert(hasattr(program, 'meta'))
-            assert(program.meta.test == 'db_id : %d' % program.db_id[1])
+            assert(hasattr(program, 'test'))
+            assert(program.test == 'db_id : %d' % program.db_id[1])
+        print
 
 
-if 1:
+if 0:
     print 'Local'
     local()
 
-if 0:
+if 1:
     print 'Remote'
     remote().wait()
 

--- a/test/query.py
+++ b/test/query.py
@@ -5,9 +5,9 @@ import kaa.epg
 def local():
     print 'Starting'
     kaa.epg.load('test.db')
-    print kaa.epg.get_channels()
+    channels = kaa.epg.get_channels()
     t1 = time.time()
-    result = kaa.epg.search(time=(time.time(), time.time() + 60*60)).wait()
+    result = kaa.epg.search(channel=channels[:2],time=(time.time(), time.time() + 60*60)).wait()
     t2 = time.time()
     for r in result:
         print r.title, r.channel
@@ -39,9 +39,8 @@ def rpc():
     print result
 
 
-if 0:
-    rpc()
-    kaa.main.run()
+if 1:
+    rpc().wait()
 
 if 1:
     local()

--- a/test/server.py
+++ b/test/server.py
@@ -2,11 +2,11 @@ import time
 import kaa.epg
 
 
-def callback(id, extrainfo):
-    extrainfo['test'] = 'db_id : %d' % id
+def callback(row, extrainfo):
+    extrainfo['test'] = 'db_id : %d' % row['id']
 
 guide = kaa.epg.load('test.db')
-guide.register_program_callback(callback)
+guide.signals['program-retrieved'].connect(callback)
 
 print kaa.epg.get_channels()
 

--- a/test/server.py
+++ b/test/server.py
@@ -2,11 +2,11 @@ import time
 import kaa.epg
 
 
-def callback(id, meta):
-    meta.test = 'db_id : %d' % id
+def callback(id, extrainfo):
+    extrainfo['test'] = 'db_id : %d' % id
 
 guide = kaa.epg.load('test.db')
-guide.register_grid_callback(callback)
+guide.register_program_callback(callback)
 
 print kaa.epg.get_channels()
 

--- a/test/server.py
+++ b/test/server.py
@@ -1,7 +1,13 @@
 import time
 import kaa.epg
 
-kaa.epg.load('test.db')
+
+def callback(id, meta):
+    meta.test = 'db_id : %d' % id
+
+guide = kaa.epg.load('test.db')
+guide.register_grid_callback(callback)
+
 print kaa.epg.get_channels()
 
 kaa.epg.listen(('localhost', 10000))


### PR DESCRIPTION
get_grid returns programs split into channels, with additional metadata added to the programs by registered callbacks.

The intention is that this is used to retrieve the grid for display with the programs also including information on whether they have been scheduled for recording/are a favorite.
